### PR TITLE
Don't pass entire SearchResults to ImageViewerActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "io.github.tjg1.nori"
         minSdkVersion 16
         targetSdkVersion 24
-        versionCode 3
-        versionName "2.1.1"
+        versionCode 4
+        versionName "2.2.0"
         testApplicationId "io.github.tjg1.nori.test"
         testInstrumentationRunner "android.test.InstrumentationTestRunner"
     }

--- a/app/src/main/java/io/github/tjg1/nori/SearchActivity.java
+++ b/app/src/main/java/io/github/tjg1/nori/SearchActivity.java
@@ -357,8 +357,9 @@ public class SearchActivity extends AppCompatActivity implements SearchResultGri
   public void onImageSelected(Image image, int position) {
     // Open ImageViewerActivity.
     final Intent intent = new Intent(SearchActivity.this, ImageViewerActivity.class);
-    intent.putExtra(BUNDLE_ID_IMAGE_INDEX, position);
-    intent.putExtra(BUNDLE_ID_SEARCH_RESULT, searchResultGridFragment.getSearchResult());
+    intent.putExtra(BUNDLE_ID_SEARCH_RESULT,
+        searchResultGridFragment.getSearchResult().getSearchResultForPage(image.searchPage));
+    intent.putExtra(BUNDLE_ID_IMAGE_INDEX, image.searchPagePosition);
     intent.putExtra(BUNDLE_ID_SEARCH_CLIENT_SETTINGS, searchClient.getSettings());
     startActivity(intent);
   }


### PR DESCRIPTION
This is to prevent TransactionTooLargeExceptions or running out of memory when scrolling too far down the GridView in SearchActivity.

Fixes #31