### PR TITLE
Fix parsing relative URLs for boards hosted outside root path

### DIFF
--- a/norilib/src/main/java/io/github/tjg1/library/norilib/clients/DanbooruLegacy.java
+++ b/norilib/src/main/java/io/github/tjg1/library/norilib/clients/DanbooruLegacy.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
+import java.net.URL;
 
 import io.github.tjg1.library.norilib.Image;
 import io.github.tjg1.library.norilib.SearchResult;
@@ -353,25 +354,13 @@ public class DanbooruLegacy implements SearchClient {
    * @param url URL to convert.
    * @return Absolute URL.
    */
-  protected String normalizeUrl(String url) {
+  protected String normalizeUrl(String url) throws java.net.MalformedURLException {
     // Return empty string for empty URLs.
     if (url == null || url.isEmpty()) {
       return "";
     }
-    // If the url starts with "//", then the http(s) part was omitted.
-    // Assume the protocol scheme to be the same as the endpoint.
-    if (url.startsWith("//")) {
-      String protocol = Uri.parse(apiEndpoint).getScheme();
-      return protocol + ":" + url;
-    } else {
-      // Prepend API endpoint path if url is relative.
-      final Uri uri = Uri.parse(url);
-      if (uri.isRelative()) {
-        return apiEndpoint + url;
-      }
-    }
-    // URL already absolute.
-    return url;
+    final String absoluteURL = new URL(new URL(apiEndpoint), url).toString();
+    return absoluteURL;
   }
 
   /**

--- a/norilib/src/main/java/io/github/tjg1/library/norilib/clients/DanbooruLegacy.java
+++ b/norilib/src/main/java/io/github/tjg1/library/norilib/clients/DanbooruLegacy.java
@@ -359,8 +359,7 @@ public class DanbooruLegacy implements SearchClient {
     if (url == null || url.isEmpty()) {
       return "";
     }
-    final String absoluteURL = new URL(new URL(apiEndpoint), url).toString();
-    return absoluteURL;
+    return new URL(new URL(apiEndpoint), url).toString();
   }
 
   /**


### PR DESCRIPTION
Patch submitted by @particularCircumstances.

> The shimmie demo page at http://shimmie.shishnet.org/v2/ is broken. The base url is saved as "http://shimmie.shishnet.org/v2/", the api answers like that "/v2/link/to/image.jpg" resulting in the full path: "http://shimmie.shishnet.org/v2//v2/link/to/image.jpg". The right result would be "http://shimmie.shishnet.org/v2/link/to/image.jpg".
> 
> "java.net.URL" seems to be quite good at merging all kinds of urls. Fixing this as well.

Fixes #94 and #86.