### PR TITLE
Integrate the ACRA crash reporting library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,8 @@ dependencies {
     compile 'com.koushikdutta.ion:ion:2.1.7'
     // Implementation of ImageView for Android that supports zooming, by various touch gestures.
     compile 'com.github.chrisbanes.photoview:library:1.2.4'
+    // Crash reporting library.
+    compile 'ch.acra:acra:4.9.2'
     // Utility library for easier unit testing.
     androidTestCompile 'org.easytesting:fest-assert-core:2.0M10'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
     android:allowBackup="true"
     android:icon="@drawable/ic_launcher"
     android:label="@string/app_name"
+    android:name=".NoriApplication"
     android:theme="@style/AppTheme">
     <activity
       android:name=".SearchActivity"

--- a/app/src/main/java/io/github/tjg1/nori/NoriApplication.java
+++ b/app/src/main/java/io/github/tjg1/nori/NoriApplication.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of nori.
+ * Copyright (c) 2014-2016 Tomasz Jan G&oacute;ralczyk <tomg@fastmail.uk>
+ * License: GNU GPLv2
+ */
+package io.github.tjg1.nori;
+
+
+import android.app.Application;
+import android.content.Context;
+import android.util.Log;
+
+import org.acra.ACRA;
+import org.acra.ReportField;
+import org.acra.ReportingInteractionMode;
+import org.acra.config.ACRAConfiguration;
+import org.acra.config.ACRAConfigurationException;
+import org.acra.config.ConfigurationBuilder;
+
+import static org.acra.ReportField.*;
+
+/**
+ * Base class for maintaining global application state.
+ */
+public class NoriApplication extends Application {
+  public static final String LOG_TAG = "io.github.tjg1.nori";
+
+  @Override
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+
+    try {
+      final ACRAConfiguration acraConfig = new ConfigurationBuilder(this)
+          //.setFormUri("") // TODO: Replace email with backend server.
+          .setMailTo("tomg@fastmail.uk")
+          .setReportingInteractionMode(ReportingInteractionMode.DIALOG)
+          .setResDialogIcon(0)
+          .setResToastText(R.string.crash_toast_text)
+          .setResDialogText(R.string.crash_dialog_text)
+          .setResDialogTitle(R.string.crash_dialog_title)
+          .setResDialogCommentPrompt(R.string.crash_dialog_comment_prompt)
+          .setResDialogPositiveButtonText(R.string.crash_dialog_positive_button_text)
+          .setResDialogNegativeButtonText(R.string.crash_dialog_negative_button_text)
+          // TODO: Uncomment when backend is set.
+          //.setResDialogOkToast(R.string.crash_dialog_ok_toast)
+          .setResDialogTheme(R.style.CrashDialogTheme)
+          .setCustomReportContent(new ReportField[]{
+              REPORT_ID, APP_VERSION_CODE, APP_VERSION_NAME, PACKAGE_NAME, PHONE_MODEL,
+              BRAND, PRODUCT, ANDROID_VERSION, BUILD, TOTAL_MEM_SIZE, AVAILABLE_MEM_SIZE,
+              CUSTOM_DATA, STACK_TRACE, INITIAL_CONFIGURATION, CRASH_CONFIGURATION, DISPLAY,
+              USER_COMMENT, USER_APP_START_DATE, USER_CRASH_DATE, DUMPSYS_MEMINFO, IS_SILENT,
+              INSTALLATION_ID, DEVICE_FEATURES, ENVIRONMENT, MEDIA_CODEC_LIST, THREAD_DETAILS,
+              BUILD_CONFIG
+          })
+          .build();
+
+      // Initialise ACRA crash reporting.
+      ACRA.init(this, acraConfig);
+    } catch (ACRAConfigurationException e) {
+      Log.e(LOG_TAG, "Failed to initialise ACRA", e);
+    }
+  }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -109,4 +109,13 @@
     <string name="donation_summary">Si disfrutas de Nori, por favor considere hacer una donación para apoyar un desarrollo continuado. Dependemos de su apoyo para mantener Nori gratis y libre de publicidad.</string>
     <string name="donation_toast_completed">Se ha recibido su donación. Gracias por su apoyo.</string>
     <string name="donation_url_copiedToClipboard">Se ha copiado la URL para donar al portapapeles.</string>
+
+    <!-- Crash reporting (fuzzy; need proof-reading) -->
+    <string name="crash_toast_text">"Nori se cerró inesperadamente.</string>
+    <string name="crash_dialog_text">Si no estaba haciendo nada confidencial (como introducir contraseñas u otra información privada), puede informar del problema para ayudar a mejorar la aplicación.</string>
+    <string name="crash_dialog_title">Informe de problemas de Nori</string>
+    <string name="crash_dialog_comment_prompt">Proporciona todos los pasos necesarios para reproducir el problema.</string>
+    <string name="crash_dialog_positive_button_text">Enviar informe</string>
+    <string name="crash_dialog_negative_button_text">No enviar</string>
+    <string name="crash_dialog_ok_toast">Los desarrolladores han recibido tu informe.</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -115,5 +115,14 @@
   <string name="donation_error_connectingToPlayStoreService">Play Store への接続エラーです - サービスへ届きません。</string>
   <string name="donation_toast_completed">ご寄付をいただきました。 ご厚意、誠にありがとうございました。</string>
 
+  <!-- Crash reporting (fuzzy; need proof-reading) -->
+  <string name="crash_toast_text">残念ながら、Noriは予期せず終了しました。</string>
+  <string name="crash_dialog_text">秘密にしておくべき作業(パスワードや個人情報の入力など)を行っていたのでなければ、不具合を報告してアプリケーションの改善に協力することができます。</string>
+  <string name="crash_dialog_title">Nori の問題レポート</string>
+  <string name="crash_dialog_comment_prompt">問題の再現に必要なすべての手順を入力してください。</string>
+  <string name="crash_dialog_positive_button_text">レポートの送信</string>
+  <string name="crash_dialog_negative_button_text">送信しない</string>
+  <string name="crash_dialog_ok_toast">問題は開発者にレポートされています。ありがとうございます!</string>
+
 
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -115,4 +115,13 @@
   <string name="donation_error_connectingToPlayStoreService">Nie można uzyskać połączenia ze sklepem Play.</string>
   <string name="donation_toast_completed">Dotacja została otrzymana. Dziękujemy za wsparcie.</string>
 
+  <!-- Crash reporting -->
+  <string name="crash_toast_text">Przepraszamy, Nori zostało niespodziewanie zakończone.</string>
+  <string name="crash_dialog_text">Jeśli wykonywana praca nie była poufna (wpisywanie haseł bądź innych prywatnych informacji), można pomóc w usprawnieniu programu zgłaszając problem.</string>
+  <string name="crash_dialog_title">Raport problemu (Nori)</string>
+  <string name="crash_dialog_comment_prompt">Opisz kroki niezbędne do powtórzenia tego problemu.</string>
+  <string name="crash_dialog_positive_button_text">Wyślij raport</string>
+  <string name="crash_dialog_negative_button_text">Nie wysyłaj</string>
+  <string name="crash_dialog_ok_toast">Twój raport został otrzymany.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,13 @@
   <string name="donation_error_connectingToPlayStoreService">Error: Couldn\'t connect to the Play Store service.</string>
   <string name="donation_toast_completed">Your donation has been received. Thank you for your support.</string>
 
+  <!-- Crash reporting -->
+  <string name="crash_toast_text">Nori quit unexpectedly.</string>
+  <string name="crash_dialog_text">If you were not doing anything confidential (entering passwords or other private information), you can help to improve the application by reporting the problem.</string>
+  <string name="crash_dialog_title">Problem Report for Nori</string>
+  <string name="crash_dialog_comment_prompt">Provide any steps necessary to reproduce the problem.</string>
+  <string name="crash_dialog_positive_button_text">Send Report</string>
+  <string name="crash_dialog_negative_button_text">Don\'t Send</string>
+  <string name="crash_dialog_ok_toast">Your report was received by the developer.</string>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,4 +24,9 @@
 
   <style name="ImageViewerActionBar" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
 
+  <style name="CrashDialogTheme" parent="Theme.AppCompat.Light.Dialog">
+    <item name="android:paddingLeft">4dp</item>
+    <item name="android:paddingRight">4dp</item>
+  </style>
+
 </resources>


### PR DESCRIPTION
Integrates [ACRA](https://github.com/ACRA/acra) to submit crash reports from end-users.

When a crash occurs, a dialog is shown giving the user a choice whether they want to submit a crash report.

![screenshot_2017-03-26_14-17-52](https://cloud.githubusercontent.com/assets/1909894/24331780/13769a1c-1233-11e7-91cd-0d88f409a371.png)

Currently the reports are sent via email (using the system Email app), until I deploy a dedicated backend, such as [acralyzer](https://github.com/ACRA/acralyzer).

Fixes #98