### PR TITLE
Partial fix for the TransactionTooLargeException issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId "io.github.tjg1.nori"

--- a/app/src/main/java/io/github/tjg1/nori/SearchActivity.java
+++ b/app/src/main/java/io/github/tjg1/nori/SearchActivity.java
@@ -14,6 +14,7 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.widget.CursorAdapter;
@@ -249,6 +250,21 @@ public class SearchActivity extends AppCompatActivity
     // Request search result from API client.
     searchCallback = new SearchResultCallback(searchResult);
     searchClient.search(Tag.stringFromArray(searchResult.getQuery()), searchResult.getCurrentOffset() + 1, searchCallback);
+  }
+
+  @Override
+  public void onRestoreSearchGridState(@NonNull String savedQuery, int firstVisiblePageOffset) {
+    // Ignore request if there is another API request pending.
+    if (searchCallback != null) {
+      return;
+    }
+
+    // Show progress bar in ActionBar.
+    searchProgressBar.setVisibility(View.VISIBLE);
+
+    // Request previous SearchResult from API client.
+    searchCallback = new SearchResultCallback();
+    searchClient.search(savedQuery, firstVisiblePageOffset, searchCallback);
   }
   //endregion
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 

--- a/norilib/build.gradle
+++ b/norilib/build.gradle
@@ -11,13 +11,13 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.0'
+    classpath 'com.android.tools.build:gradle:2.3.2'
   }
 }
 
 android {
   compileSdkVersion 25
-  buildToolsVersion "25.0.2"
+  buildToolsVersion "25.0.3"
 
   defaultConfig {
     minSdkVersion 10


### PR DESCRIPTION
This patch implements a fix for the android.os.TransactionTooLargeException crash that has been plaguing the current release.

Instead of saving the entire huge `SearchResult` object to SearchResultGridFragment's instance state bundle, it stores just enough information to fetch the same* SearchResult from the network or (hopefully) ion's disk cache.

* The SearchResult could have changed on the remote server as more Images got uploaded to the service in the meantime.

Could be backported to current release.